### PR TITLE
bad hack: use async file transfer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-downloadfile",
   "description": "The best Grunt plugin ever.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/mCzolko/grunt-downloadfile",
   "author": {
     "name": "Michael Czolko",

--- a/tasks/downloadfile.js
+++ b/tasks/downloadfile.js
@@ -116,19 +116,19 @@ module.exports = function(grunt) {
     var chunkedResponse = function(file, response) {
       file.downloading = true;
 
-      var downloadfile = fs.createWriteStream(file.tmpPath, {'flags': 'a'});
+      var downloadfile = fs.openSync(file.tmpPath, 'w');
 
       file['size'] = response.headers['content-length'];
 
       response.on('data', function (chunk) {
         file.dlprogress += chunk.length;
-        downloadfile.write(chunk);
+        fs.writeSync(downloadfile, chunk);
         notify();
       });
 
       response.on("end", function() {
-        downloadfile.end();
-        fs.renameSync(file.tmpPath, file.filePath)
+        fs.closeSync(downloadfile);
+        fs.renameSync(file.tmpPath, file.filePath);
         file.downloaded = true;
         file.downloading = false;
         downloadNext();


### PR DESCRIPTION
the 'end' from the http request calls earlier than the write of the file-stream.
